### PR TITLE
Add .html type filter and test for new filter

### DIFF
--- a/PlainPasta.xcodeproj/project.pbxproj
+++ b/PlainPasta.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = software.level.PlainPasta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -494,7 +494,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = software.level.PlainPasta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PlainPasta/NSPasteboardItem+Extras.swift
+++ b/PlainPasta/NSPasteboardItem+Extras.swift
@@ -15,6 +15,7 @@ extension NSPasteboardItem {
 
 		/// All of the types of pasteboard data to filter out when copying pasteboard data
 		let pasteboardTypeFilterList: [NSPasteboard.PasteboardType] = [
+			.html,
 			.rtf,
 			.rtfd,
 			NSPasteboard.PasteboardType("public.url-name"),

--- a/PlainPasta/PasteboardMonitor.swift
+++ b/PlainPasta/PasteboardMonitor.swift
@@ -34,10 +34,6 @@ class PasteboardMonitor {
 	deinit {
 		timer.setEventHandler {}
 		timer.cancel()
-
-		// If the timer is suspended, calling cancel without resuming triggers a crash.
-		// This is documented here: https://forums.developer.apple.com/thread/15902
-		timer.resume()
 	}
 
 	/// The current state of the pasteboard monitor

--- a/PlainPastaTests/PlainPastaTests.swift
+++ b/PlainPastaTests/PlainPastaTests.swift
@@ -29,6 +29,7 @@ class PlainPastaTests: XCTestCase {
 		mockPasteboardItem.setData(Data(), forType: .pdf)
 
 		// Pasteboard types Plain Pasta will explicitly filter
+		mockPasteboardItem.setString("html", forType: .html)
 		mockPasteboardItem.setString("rtf", forType: .rtf)
 		mockPasteboardItem.setString("rtfd", forType: .rtfd)
 		mockPasteboardItem.setString(
@@ -58,6 +59,7 @@ class PlainPastaTests: XCTestCase {
 		XCTAssertNotNil(filteredComplexPasteboardItem.data(forType: .pdf))
 
 		// Check types that should have been filtered
+		XCTAssertNil(filteredComplexPasteboardItem.string(forType: .html))
 		XCTAssertNil(filteredComplexPasteboardItem.string(forType: .rtf))
 		XCTAssertNil(filteredComplexPasteboardItem.string(forType: .rtfd))
 		XCTAssertNil(

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2020-09-12
+
+### Added
+
+- Adds `.html` to the pasteboard types to filter.
+- Adds a test for the `.html` filter.
+
 ## [1.1.3] - 2020-09-10
 
 ### Fixed
@@ -65,3 +72,4 @@ Initial release! 🎉
 [1.1.1]: https://github.com/hisaac/PlainPasta/compare/1.1.0...1.1.1
 [1.1.2]: https://github.com/hisaac/PlainPasta/compare/1.1.1...1.1.2
 [1.1.3]: https://github.com/hisaac/PlainPasta/compare/1.1.2...1.1.3
+[1.1.4]: https://github.com/hisaac/PlainPasta/compare/1.1.3...1.1.4

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,7 +119,7 @@
 		<h1>Plain Pasta</h1>
 
 		<figure>
-			<a href="https://github.com/hisaac/PlainPasta/releases/download/1.1.3/PlainPasta-1.1.3.zip" alt="Download the latest version of Plain Pasta">
+			<a href="https://github.com/hisaac/PlainPasta/releases/download/1.1.4/PlainPasta-1.1.4.zip" alt="Download the latest version of Plain Pasta">
 				<svg width="200px" height="200px" viewBox="0 0 1900 1900" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 					<!-- Generator: Sketch 52.2 (67145) - http://www.bohemiancoding.com/sketch -->
 					<title>vector-Artboard</title>
@@ -129,7 +129,7 @@
 					</g>
 				</svg>
 			</a>
-			<figcaption><a href="https://github.com/hisaac/PlainPasta/releases/download/1.1.3/PlainPasta-1.1.3.zip" alt="Download the latest version of Plain Pasta">Download App</a></figcaption>
+			<figcaption><a href="https://github.com/hisaac/PlainPasta/releases/download/1.1.4/PlainPasta-1.1.4.zip" alt="Download the latest version of Plain Pasta">Download App</a></figcaption>
 		</figure>
 	</header>
 


### PR DESCRIPTION
### Added

- Adds `.html` to the pasteboard types to filter.
- Adds a test for the `.html` filter.